### PR TITLE
Fix port value issue

### DIFF
--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -47,8 +47,7 @@ defmodule Kadabra.Connection do
       :http -> {:error, :not_implemented}
       :https ->
         :ssl.start
-        port = opts[:port] || 443
-        case :ssl.connect(uri, port, ssl_options(opts[:ssl])) do
+        case :ssl.connect(uri, opts[:port], ssl_options(opts[:ssl])) do
           {:ok, ssl} ->
             :ssl.send(ssl, Http2.connection_preface)
             :ssl.send(ssl, Http2.settings_frame)

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -5,7 +5,9 @@ defmodule Kadabra do
   alias Kadabra.{Connection}
 
   def open(uri, scheme, opts \\ []) do
-    case Connection.start_link(uri, self, scheme: scheme, ssl: opts) do
+    port = opts[:port] || 443
+    nopts = List.keydelete opts, :port, 0
+    case Connection.start_link(uri, self, scheme: scheme, ssl: nopts, port: port) do
       {:ok, pid} -> {:ok, pid}
       {:error, reason} -> {:error, reason}
     end


### PR DESCRIPTION
The `:port` option was always ignored. Now is as expected.