### PR TITLE
Fix applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Kadabra.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp description do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Kadabra.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [applications: [:logger, :hpack]]
   end
 
   defp description do


### PR DESCRIPTION
According to elixir docs: `Mix v1.4 now automatically infers your applications list as long as you leave the :applications key empty`. 

Application inference didn't work so there was an error with HPack not being started.