### PR TITLE
Sort headers, pseudo headers first

### DIFF
--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -174,10 +174,13 @@ defmodule Kadabra.Connection do
   end
 
   defp add_headers(headers, uri, state) do
-    headers ++ [
+    h = headers ++
+    [
       {":scheme", Atom.to_string(state[:scheme])},
       {":authority", List.to_string(uri)}
     ]
+    # sorting headers to have pseudo headers first.
+    Enum.sort h, fn({a, b}, {c, d})-> a < c end
   end
 
   defp do_send_goaway(%{socket: socket, stream_id: stream_id}) do


### PR DESCRIPTION
From http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.1:
"All pseudo-header fields MUST appear in the header block before regular header fields. Any request or response that contains a pseudo-header field that appears in a header block after a regular header field MUST be treated as malformed"