### PR TITLE
Stream :gen_statem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 18.3
-      elixir: 1.3.2
     - otp_release: 19.0
-      elixir: 1.3.2
+      elixir: 1.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: elixir
 matrix:
   include:
     - otp_release: 19.0
-      elixir: 1.4.2
+      elixir: 1.4.5
     - otp_release: 20.0
       elixir: 1.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ matrix:
   include:
     - otp_release: 19.0
       elixir: 1.4.2
+    - otp_release: 20.0
+      elixir: 1.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 19.0
-      elixir: 1.4.0
+    - otp_release: 19
+      elixir: 1.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 19.0
+    - otp_release: 19.1
       elixir: 1.4.5
     - otp_release: 20.0
       elixir: 1.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 19
+    - otp_release: 19.0
       elixir: 1.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 19.1
+    - otp_release: 19.2
       elixir: 1.4.5
     - otp_release: 20.0
       elixir: 1.4.5

--- a/config/dogma.exs
+++ b/config/dogma.exs
@@ -1,0 +1,17 @@
+use Mix.Config
+alias Dogma.Rule
+
+config :dogma,
+
+  # Select a set of rules as a base
+  rule_set: Dogma.RuleSet.All,
+
+  # Pick paths not to lint
+  exclude: [
+    ~r(\Alib/vendor/),
+  ],
+
+  # Override an existing rule configuration
+  override: [
+    %Rule.LineLength{ max_length: 100 },
+  ]

--- a/frame/push_promise.ex
+++ b/frame/push_promise.ex
@@ -1,3 +1,0 @@
-defmodule Kadabra.Frame.PushPromise do
-  defstruct [:stream_id, :headers, end_headers: false]
-end

--- a/frame/push_promise.ex
+++ b/frame/push_promise.ex
@@ -1,0 +1,3 @@
+defmodule Kadabra.Frame.PushPromise do
+  defstruct [:stream_id, :headers, end_headers: false]
+end

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -1,0 +1,13 @@
+defmodule Kadabra.Application do
+  @moduledoc false
+
+  use Application
+  import Supervisor.Spec
+
+  def start(_type, _args) do
+    children = [
+      supervisor(Registry, [:unique, Registry.Kadabra])
+    ]
+    Supervisor.start_link(children, [strategy: :one_for_one, name: :kadabra])
+  end
+end

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -17,7 +17,7 @@ defmodule Kadabra.Connection do
   use GenServer
   require Logger
 
-  alias Kadabra.{Error, Frame, Http2, Stream}
+  alias Kadabra.{Encodable, Error, Frame, Http2, Stream}
   alias Kadabra.Frame.{Continuation, Data, Goaway, Headers, Ping,
     PushPromise, RstStream, WindowUpdate}
 
@@ -133,9 +133,8 @@ defmodule Kadabra.Connection do
     {:noreply, state}
   end
 
-
   def handle_cast({:send, :ping}, %{socket: socket} = state) do
-    bin = Ping.new |> Ping.to_bin
+    bin = Ping.new |> Encodable.to_bin
     :ssl.send(socket, bin)
     {:noreply, state}
   end
@@ -164,7 +163,7 @@ defmodule Kadabra.Connection do
   end
 
   defp do_send_goaway(%{socket: socket, stream_id: stream_id}) do
-    bin = stream_id |> Goaway.new |> Goaway.to_bin
+    bin = stream_id |> Goaway.new |> Encodable.to_bin
     :ssl.send(socket, bin)
   end
 

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -223,7 +223,7 @@ defmodule Kadabra.Connection do
   end
 
   def handle_info({:ssl_closed, _socket}, state) do
-   maybe_reconnect(state)
+    maybe_reconnect(state)
   end
 
   defp do_recv_ssl(bin, %{socket: socket} = state) do

--- a/lib/connection/settings.ex
+++ b/lib/connection/settings.ex
@@ -1,0 +1,55 @@
+defmodule Kadabra.Connection.Settings do
+  defstruct header_table_size: 4096,
+            enable_push: true,
+            max_concurrent_streams: nil,
+            initial_window_size: 65_535,
+            max_frame_size: 16_384,
+            max_header_list_size: nil
+
+  alias Kadabra.Error
+
+  @table_header_size 0x1
+  @enable_push 0x2
+  @max_concurrent_streams 0x3
+  @initial_window_size 0x4
+  @max_frame_size 0x5
+  @max_header_list_size 0x6
+
+  def put(settings, @table_header_size, value) do
+    {:ok, %{settings | table_header_size: value}}
+  end
+
+  def put(settings, @enable_push, 1) do
+    {:ok, %{settings | enable_push: true}}
+  end
+  def put(settings, @enable_push, 0) do
+    {:ok, %{settings | enable_push: false}}
+  end
+  def put(settings, @enable_push, _else) do
+    {:error, Error.protocol_error, settings}
+  end
+
+  def put(settings, @max_concurrent_streams, value) do
+    {:ok, %{settings | max_concurrent_streams: value}}
+  end
+
+  def put(settings, @initial_window_size, value) when value > 4_294_967_295 do
+    {:error, Error.flow_control_error, settings}
+  end
+  def put(settings, @initial_window_size, value) do
+    {:ok, %{settings | initial_window_size: value}}
+  end
+
+  def put(settings, @max_frame_size, value) when value > 16_777_215 or value < 16_384 do
+    {:error, Error.protocol_error, settings}
+  end
+  def put(settings, @max_frame_size, value) do
+    {:ok, %{settings | max_frame_size: value}}
+  end
+
+  def put(settings, @max_header_list_size, value) do
+    {:ok, %{settings | max_header_list_size: value}}
+  end
+
+  def put(settings, _else, _value), do: {:ok, settings}
+end

--- a/lib/encodable.ex
+++ b/lib/encodable.ex
@@ -1,0 +1,6 @@
+defprotocol Kadabra.Encodable do
+  @doc ~S"""
+  Packs frame into sendable frame with frame header.
+  """
+  def to_bin(frame)
+end

--- a/lib/encodable.ex
+++ b/lib/encodable.ex
@@ -2,5 +2,14 @@ defprotocol Kadabra.Encodable do
   @doc ~S"""
   Packs frame into sendable frame with frame header.
   """
+
+  @dialyzer {:nowarn_function, __protocol__: 1}
+  @fallback_to_any true
+
+  @spec to_bin(any) :: bitstring | :error
   def to_bin(frame)
+end
+
+defimpl Kadabra.Encodable, for: Any do
+  def to_bin(_), do: :error
 end

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -29,7 +29,7 @@ defmodule Kadabra.Error do
       iex> Kadabra.Error.protocol_error
       <<0, 0, 0, 1>>
   """
-  @spec no_error :: <<_::32>>
+  @spec protocol_error :: <<_::32>>
   def protocol_error, do: <<1::32>>
 
   @doc ~S"""

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,6 +1,6 @@
 defmodule Kadabra.Error do
   @moduledoc """
-    Handles error code conversions.
+  Handles error code conversions.
   """
   def string(code) do
     case code do

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -6,6 +6,10 @@ defmodule Kadabra.Error do
   @doc ~S"""
   32-bit error code of type NO_ERROR
 
+  The associated condition is not a result of an error. For example,
+  a GOAWAY might include this code to indicate graceful shutdown of
+  a connection.
+
   ## Examples
     
       iex> Kadabra.Error.no_error
@@ -17,6 +21,9 @@ defmodule Kadabra.Error do
   @doc ~S"""
   32-bit error code of type PROTOCOL_ERROR
 
+  The endpoint detected an unspecific protocol error. This error is for use
+  when a more specific error code is not available.
+
   ## Examples
     
       iex> Kadabra.Error.protocol_error
@@ -24,6 +31,19 @@ defmodule Kadabra.Error do
   """
   @spec no_error :: <<_::32>>
   def protocol_error, do: <<1::32>>
+
+  @doc ~S"""
+  32-bit error code of type FLOW_CONTROL_ERROR
+
+  The endpoint detected that its peer violated the flow-control protocol.
+
+  ## Examples
+    
+      iex> Kadabra.Error.flow_control_error
+      <<0, 0, 0, 3>>
+  """
+  @spec flow_control_error :: <<_::32>>
+  def flow_control_error, do: <<3::32>>
 
   @doc ~S"""
   32-bit error code of type FRAME_SIZE_ERROR

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -2,6 +2,40 @@ defmodule Kadabra.Error do
   @moduledoc """
   Handles error code conversions.
   """
+
+  @doc ~S"""
+  32-bit error code of type NO_ERROR
+
+  ## Examples
+    
+      iex> Kadabra.Error.no_error
+      <<0, 0, 0, 0>>
+  """
+  @spec no_error :: <<_::32>>
+  def no_error, do: <<0::32>>
+
+  @doc ~S"""
+  32-bit error code of type PROTOCOL_ERROR
+
+  ## Examples
+    
+      iex> Kadabra.Error.protocol_error
+      <<0, 0, 0, 1>>
+  """
+  @spec no_error :: <<_::32>>
+  def protocol_error, do: <<1::32>>
+
+  @doc ~S"""
+  32-bit error code of type FRAME_SIZE_ERROR
+
+  ## Examples
+    
+      iex> Kadabra.Error.frame_size_error
+      <<0, 0, 0, 6>>
+  """
+  @spec frame_size_error :: <<_::32>>
+  def frame_size_error, do: <<6::32>>
+
   def string(code) do
     case code do
       0x0 -> "NO_ERROR"
@@ -24,20 +58,20 @@ defmodule Kadabra.Error do
 
   def code(string) do
     case string do
-      "NO_ERROR"           -> 0x0
-      "PROTOCOL_ERROR"     -> 0x1
-      "INTERNAL_ERROR"     -> 0x2
-      "FLOW_CONTROL_ERROR" -> 0x3
-      "SETTINGS_TIMEOUT"   -> 0x4
-      "STREAM_CLOSED"      -> 0x5
-      "FRAME_SIZE_ERROR"   -> 0x6
-      "REFUSED_STREAM"     -> 0x7
-      "CANCEL"             -> 0x8
-      "COMPRESSION_ERROR"  -> 0x9
-      "CONNECT_ERROR"      -> 0xa
-      "ENHANCE_YOUR_CALM"  -> 0xb
+      "NO_ERROR"            -> 0x0
+      "PROTOCOL_ERROR"      -> 0x1
+      "INTERNAL_ERROR"      -> 0x2
+      "FLOW_CONTROL_ERROR"  -> 0x3
+      "SETTINGS_TIMEOUT"    -> 0x4
+      "STREAM_CLOSED"       -> 0x5
+      "FRAME_SIZE_ERROR"    -> 0x6
+      "REFUSED_STREAM"      -> 0x7
+      "CANCEL"              -> 0x8
+      "COMPRESSION_ERROR"   -> 0x9
+      "CONNECT_ERROR"       -> 0xa
+      "ENHANCE_YOUR_CALM"   -> 0xb
       "INADEQUATE_SECURITY" -> 0xc
-      "HTTP_1_1_REQUIRED"  -> 0xd
+      "HTTP_1_1_REQUIRED"   -> 0xd
       error -> "Unknown Error: #{inspect(error)}"
     end
   end

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -4,7 +4,7 @@ defmodule Kadabra.Error do
   """
 
   @doc ~S"""
-  32-bit error code of type NO_ERROR
+  32-bit error code of type `NO_ERROR`
 
   The associated condition is not a result of an error. For example,
   a GOAWAY might include this code to indicate graceful shutdown of
@@ -19,7 +19,7 @@ defmodule Kadabra.Error do
   def no_error, do: <<0::32>>
 
   @doc ~S"""
-  32-bit error code of type PROTOCOL_ERROR
+  32-bit error code of type `PROTOCOL_ERROR`
 
   The endpoint detected an unspecific protocol error. This error is for use
   when a more specific error code is not available.
@@ -33,7 +33,7 @@ defmodule Kadabra.Error do
   def protocol_error, do: <<1::32>>
 
   @doc ~S"""
-  32-bit error code of type FLOW_CONTROL_ERROR
+  32-bit error code of type `FLOW_CONTROL_ERROR`
 
   The endpoint detected that its peer violated the flow-control protocol.
 
@@ -46,7 +46,7 @@ defmodule Kadabra.Error do
   def flow_control_error, do: <<3::32>>
 
   @doc ~S"""
-  32-bit error code of type FRAME_SIZE_ERROR
+  32-bit error code of type `FRAME_SIZE_ERROR`
 
   ## Examples
     

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -1,0 +1,35 @@
+defmodule Kadabra.Frame do
+  defstruct [:length, :type, :flags, :stream_id, :payload]
+
+  def new(<<payload_size::24,
+            frame_type::8,
+            flags::8,
+            0::1,
+            stream_id::31,
+            payload::bitstring>> = bin) do
+
+    size = payload_size * 8
+
+    case parse_payload(size, payload) do
+      {:ok, frame_payload, rest} ->
+        {:ok, %Kadabra.Frame{
+          length: payload_size,
+          type: frame_type,
+          flags: flags,
+          stream_id: stream_id,
+          payload: frame_payload
+        }, rest}
+      {:error, _bin} ->
+        {:error, bin}
+    end
+  end
+  def new(bin), do: {:error, bin}
+
+  def parse_payload(size, bin) do
+    case bin do
+      <<frame_payload::size(size), rest::bitstring>> ->
+        {:ok, <<frame_payload::size(size)>>, <<rest::bitstring>>}
+      bin -> {:error, <<bin::bitstring>>}
+    end
+  end
+end

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -15,7 +15,7 @@ defmodule Kadabra.Frame do
         {:ok, %Kadabra.Frame{
           length: payload_size,
           type: frame_type,
-          flags: flags,
+          flags: <<flags::bitstring>>,
           stream_id: stream_id,
           payload: frame_payload
         }, rest}

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -1,6 +1,16 @@
 defmodule Kadabra.Frame do
   defstruct [:length, :type, :flags, :stream_id, :payload]
 
+  @data 0x0
+  @headers 0x1
+  @rst_stream 0x3
+  @settings 0x4
+  @push_promise 0x5
+  @ping 0x6
+  @goaway 0x7
+  @window_update 0x8
+  @continuation 0x9
+
   @type t :: %__MODULE__{
     length: non_neg_integer,
     type: non_neg_integer,

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -1,6 +1,14 @@
 defmodule Kadabra.Frame do
   defstruct [:length, :type, :flags, :stream_id, :payload]
 
+  @type t :: %__MODULE__{
+    length: non_neg_integer,
+    type: non_neg_integer,
+    flags: <<_::8>>,
+    stream_id: non_neg_integer,
+    payload: bitstring
+  }
+
   def new(<<payload_size::24,
             frame_type::8,
             flags::8,
@@ -15,7 +23,7 @@ defmodule Kadabra.Frame do
         {:ok, %Kadabra.Frame{
           length: payload_size,
           type: frame_type,
-          flags: <<flags::bitstring>>,
+          flags: <<flags::8>>,
           stream_id: stream_id,
           payload: frame_payload
         }, rest}

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -1,16 +1,6 @@
 defmodule Kadabra.Frame do
   defstruct [:length, :type, :flags, :stream_id, :payload]
 
-  @data 0x0
-  @headers 0x1
-  @rst_stream 0x3
-  @settings 0x4
-  @push_promise 0x5
-  @ping 0x6
-  @goaway 0x7
-  @window_update 0x8
-  @continuation 0x9
-
   @type t :: %__MODULE__{
     length: non_neg_integer,
     type: non_neg_integer,

--- a/lib/frame/continuation.ex
+++ b/lib/frame/continuation.ex
@@ -1,10 +1,12 @@
 defmodule Kadabra.Frame.Continuation do
   defstruct [:header_block_fragment, end_headers: false]
 
-  def new(%{} = frame) do
+  alias Kadabra.Frame.Flags
+
+  def new(%{payload: payload, flags: flags}) do
     %__MODULE__{
-      header_block_fragment: frame.payload,
-      end_headers: (frame.flags == 0x4)
+      header_block_fragment: payload,
+      end_headers: Flags.end_headers?(flags)
     }
   end
 end

--- a/lib/frame/continuation.ex
+++ b/lib/frame/continuation.ex
@@ -1,8 +1,14 @@
 defmodule Kadabra.Frame.Continuation do
   defstruct [:header_block_fragment, end_headers: false]
 
+  @type t :: %__MODULE__{
+    end_headers: boolean,
+    header_block_fragment: bitstring
+  }
+
   alias Kadabra.Frame.Flags
 
+  @spec new(Kadabra.Frame.t) :: t
   def new(%{payload: payload, flags: flags}) do
     %__MODULE__{
       header_block_fragment: payload,

--- a/lib/frame/continuation.ex
+++ b/lib/frame/continuation.ex
@@ -1,0 +1,10 @@
+defmodule Kadabra.Frame.Continuation do
+  defstruct [:header_block_fragment, end_headers: false]
+
+  def new(%{} = frame) do
+    %__MODULE__{
+      header_block_fragment: frame.payload,
+      end_headers: (frame.flags == 0x4)
+    }
+  end
+end

--- a/lib/frame/data.ex
+++ b/lib/frame/data.ex
@@ -1,13 +1,12 @@
 defmodule Kadabra.Frame.Data do
   defstruct [:data, end_stream: false]
 
+  alias Kadabra.Frame.Flags
+
   def new(%{payload: data, flags: flags}) do
     %__MODULE__{
       data: data,
-      end_stream: end_stream?(flags)
+      end_stream: Flags.end_stream?(flags)
     }
   end
-
-  def end_stream?(0x1), do: true
-  def end_stream?(_flags), do: false
 end

--- a/lib/frame/data.ex
+++ b/lib/frame/data.ex
@@ -1,0 +1,13 @@
+defmodule Kadabra.Frame.Data do
+  defstruct [:data, end_stream: false]
+
+  def new(%{payload: data, flags: flags}) do
+    %__MODULE__{
+      data: data,
+      end_stream: end_stream?(flags)
+    }
+  end
+
+  def end_stream?(0x1), do: true
+  def end_stream?(_flags), do: false
+end

--- a/lib/frame/flags.ex
+++ b/lib/frame/flags.ex
@@ -1,6 +1,16 @@
 defmodule Kadabra.Frame.Flags do
 
   @doc ~S"""
+  Returns `ACK` flag.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.ack
+      <<0::7, 1::1>>
+  """
+  def ack, do: <<0::7, 1::1>>
+
+  @doc ~S"""
   Returns `true` if bit 0 is set to 1.
 
   ## Examples
@@ -17,7 +27,7 @@ defmodule Kadabra.Frame.Flags do
   """
   def ack?(<<_::7, 1::1>>), do: true
   def ack?(0x1), do: true
-  def ack?(_), do: false
+  def ack?(_ack), do: false
 
   @doc ~S"""
   Returns `true` if bit 5 is set to 1.

--- a/lib/frame/flags.ex
+++ b/lib/frame/flags.ex
@@ -1,0 +1,78 @@
+defmodule Kadabra.Frame.Flags do
+
+  @doc ~S"""
+  Returns `true` if bit 0 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.ack?(<<0::7, 1::1>>)
+      true
+      iex> Kadabra.Frame.Flags.ack?(0x1)
+      true
+
+      iex> Kadabra.Frame.Flags.ack?(<<0::8>>)
+      false
+      iex> Kadabra.Frame.Flags.ack?(0)
+      false
+  """
+  def ack?(<<_::7, 1::1>>), do: true
+  def ack?(0x1), do: true
+  def ack?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 5 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.priority?(<<0::2, 1::1, 0::5>>)
+      true
+
+      iex> Kadabra.Frame.Flags.priority?(<<0::8>>)
+      false
+  """
+  def priority?(<<_::2, 1::1, _::5>>), do: true
+  def priority?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 3 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.padded?(<<0::5, 1::1, 0::2>>)
+      true
+
+      iex> Kadabra.Frame.Flags.padded?(<<0::8>>)
+      false
+  """
+  def padded?(<<_::5, 1::1, _::2>>), do: true
+  def padded?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 2 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.end_headers?(<<0::6, 1::1, 0::1>>)
+      true
+
+      iex> Kadabra.Frame.Flags.end_headers?(<<0::8>>)
+      false
+  """
+  def end_headers?(<<_::6, 1::1, _::1>>), do: true
+  def end_headers?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 0 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Flags.end_stream?(<<0::7, 1::1>>)
+      true
+
+      iex> Kadabra.Frame.Flags.end_stream?(<<0::8>>)
+      false
+  """
+  def end_stream?(<<_::7, 1::1>>), do: true
+  def end_stream?(0x1), do: true
+  def end_stream?(_), do: false
+end

--- a/lib/frame/flags.ex
+++ b/lib/frame/flags.ex
@@ -1,5 +1,4 @@
 defmodule Kadabra.Frame.Flags do
-
   @doc ~S"""
   Returns `ACK` flag.
 

--- a/lib/frame/goaway.ex
+++ b/lib/frame/goaway.ex
@@ -1,7 +1,7 @@
 defmodule Kadabra.Frame.Goaway do
   defstruct [:last_stream_id, :error_code, :debug_data]
 
-  alias Kadabra.{Error, Frame, Http2}
+  alias Kadabra.{Error, Frame}
 
   @type t :: %__MODULE__{
     debug_data: bitstring,
@@ -31,8 +31,10 @@ defmodule Kadabra.Frame.Goaway do
 end
 
 defimpl Kadabra.Encodable, for: Kadabra.Frame.Goaway do
+  alias Kadabra.Http2
+
   def to_bin(%{last_stream_id: id, error_code: error}) do
     payload = <<0::1, id::31>> <> error
-    Kadabra.Http2.build_frame(0x7, 0x0, 0, payload)
+    Http2.build_frame(0x7, 0x0, 0, payload)
   end
 end

--- a/lib/frame/goaway.ex
+++ b/lib/frame/goaway.ex
@@ -1,8 +1,15 @@
 defmodule Kadabra.Frame.Goaway do
-  defstruct [:last_stream_id, :error_code, :debug_data]  
+  defstruct [:last_stream_id, :error_code, :debug_data]
 
-  alias Kadabra.{Error, Http2}
+  alias Kadabra.{Error, Frame, Http2}
 
+  @type t :: %__MODULE__{
+    debug_data: bitstring,
+    error_code: <<_::32>>,
+    last_stream_id: non_neg_integer,
+  }
+
+  @spec new(non_neg_integer) :: t
   def new(stream_id) when is_integer(stream_id) do
     %__MODULE__{
       last_stream_id: stream_id,
@@ -10,17 +17,19 @@ defmodule Kadabra.Frame.Goaway do
     }
   end
 
-  def new(%{payload: <<_r::1,
-                       last_stream_id::31,
-                       error_code::32,
-                       debug_data::bitstring>>}) do
+  @spec new(Frame.t) :: t
+  def new(%Frame{payload: <<_r::1,
+                            last_stream_id::31,
+                            error_code::32,
+                            debug_data::bitstring>>}) do
     %__MODULE__{
       last_stream_id: last_stream_id,
       error_code: error_code,
       debug_data: debug_data
     }
-  end 
+  end
 
+  @spec to_bin(t) :: binary
   def to_bin(%{last_stream_id: id, error_code: error}) do
     payload = <<0::1, id::31>> <> error
     Http2.build_frame(0x7, 0x0, 0, payload)

--- a/lib/frame/goaway.ex
+++ b/lib/frame/goaway.ex
@@ -1,0 +1,28 @@
+defmodule Kadabra.Frame.Goaway do
+  defstruct [:last_stream_id, :error_code, :debug_data]  
+
+  alias Kadabra.{Error, Http2}
+
+  def new(stream_id) when is_integer(stream_id) do
+    %__MODULE__{
+      last_stream_id: stream_id,
+      error_code: Error.no_error
+    }
+  end
+
+  def new(%{payload: <<_r::1,
+                       last_stream_id::31,
+                       error_code::32,
+                       debug_data::bitstring>>}) do
+    %__MODULE__{
+      last_stream_id: last_stream_id,
+      error_code: error_code,
+      debug_data: debug_data
+    }
+  end 
+
+  def to_bin(%{last_stream_id: id, error_code: error}) do
+    payload = <<0::1, id::31>> <> error
+    Http2.build_frame(0x7, 0x0, 0, payload)
+  end
+end

--- a/lib/frame/goaway.ex
+++ b/lib/frame/goaway.ex
@@ -28,10 +28,11 @@ defmodule Kadabra.Frame.Goaway do
       debug_data: debug_data
     }
   end
+end
 
-  @spec to_bin(t) :: binary
+defimpl Kadabra.Encodable, for: Kadabra.Frame.Goaway do
   def to_bin(%{last_stream_id: id, error_code: error}) do
     payload = <<0::1, id::31>> <> error
-    Http2.build_frame(0x7, 0x0, 0, payload)
+    Kadabra.Http2.build_frame(0x7, 0x0, 0, payload)
   end
 end

--- a/lib/frame/headers.ex
+++ b/lib/frame/headers.ex
@@ -2,15 +2,17 @@ defmodule Kadabra.Frame.Headers do
   defstruct [:stream_dependency, :weight, :exclusive, :header_block_fragment,
     priority: false, end_stream: false, end_headers: false]
 
+  alias Kadabra.Frame.Flags
+
   def new(%{flags: flags, payload: p}) do
     frame =
       %__MODULE__{
-        end_stream: end_stream?(flags),
-        end_headers: end_headers?(flags),
-        priority: priority?(flags)
+        end_stream: Flags.end_stream?(flags),
+        end_headers: Flags.end_headers?(flags),
+        priority: Flags.priority?(flags)
       }
 
-    if priority?(flags) do
+    if Flags.priority?(flags) do
       <<e::1, stream_dep::31, weight::8, headers::bitstring>> = p
       %{frame |
         stream_dependency: stream_dep,
@@ -22,60 +24,4 @@ defmodule Kadabra.Frame.Headers do
       %{frame | header_block_fragment: p}
     end
   end
-
-  @doc ~S"""
-  Returns `true` if bit 5 is set to 1.
-
-  ## Examples
-
-      iex> Kadabra.Frame.Headers.priority?(<<0::2, 1::1, 0::5>>)
-      true
-
-      iex> Kadabra.Frame.Headers.priority?(<<0::8>>)
-      false
-  """
-  def priority?(<<_::2, 1::1, _::5>>), do: true
-  def priority?(_), do: false
-
-  @doc ~S"""
-  Returns `true` if bit 3 is set to 1.
-
-  ## Examples
-
-      iex> Kadabra.Frame.Headers.padded?(<<0::5, 1::1, 0::2>>)
-      true
-
-      iex> Kadabra.Frame.Headers.padded?(<<0::8>>)
-      false
-  """
-  def padded?(<<_::5, 1::1, _::2>>), do: true
-  def padded?(_), do: false
-
-  @doc ~S"""
-  Returns `true` if bit 2 is set to 1.
-
-  ## Examples
-
-      iex> Kadabra.Frame.Headers.end_headers?(<<0::6, 1::1, 0::1>>)
-      true
-
-      iex> Kadabra.Frame.Headers.end_headers?(<<0::8>>)
-      false
-  """
-  def end_headers?(<<_::6, 1::1, _::1>>), do: true
-  def end_headers?(_), do: false
-
-  @doc ~S"""
-  Returns `true` if bit 0 is set to 1.
-
-  ## Examples
-
-      iex> Kadabra.Frame.Headers.end_stream?(<<0::7, 1::1>>)
-      true
-
-      iex> Kadabra.Frame.Headers.end_stream?(<<0::8>>)
-      false
-  """
-  def end_stream?(<<_::7, 1::1>>), do: true
-  def end_stream?(_), do: false
 end

--- a/lib/frame/headers.ex
+++ b/lib/frame/headers.ex
@@ -1,0 +1,81 @@
+defmodule Kadabra.Frame.Headers do
+  defstruct [:stream_dependency, :weight, :exclusive, :header_block_fragment,
+    priority: false, end_stream: false, end_headers: false]
+
+  def new(%{flags: flags, payload: p}) do
+    frame =
+      %__MODULE__{
+        end_stream: end_stream?(flags),
+        end_headers: end_headers?(flags),
+        priority: priority?(flags)
+      }
+
+    if priority?(flags) do
+      <<e::1, stream_dep::31, weight::8, headers::bitstring>> = p
+      %{frame |
+        stream_dependency: stream_dep,
+        exclusive: (e == 1),
+        weight: weight,
+        header_block_fragment: headers
+      }
+    else
+      %{frame | header_block_fragment: p}
+    end
+  end
+
+  @doc ~S"""
+  Returns `true` if bit 5 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Headers.priority?(<<0::2, 1::1, 0::5>>)
+      true
+
+      iex> Kadabra.Frame.Headers.priority?(<<0::8>>)
+      false
+  """
+  def priority?(<<_::2, 1::1, _::5>>), do: true
+  def priority?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 3 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Headers.padded?(<<0::5, 1::1, 0::2>>)
+      true
+
+      iex> Kadabra.Frame.Headers.padded?(<<0::8>>)
+      false
+  """
+  def padded?(<<_::5, 1::1, _::2>>), do: true
+  def padded?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 2 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Headers.end_headers?(<<0::6, 1::1, 0::1>>)
+      true
+
+      iex> Kadabra.Frame.Headers.end_headers?(<<0::8>>)
+      false
+  """
+  def end_headers?(<<_::6, 1::1, _::1>>), do: true
+  def end_headers?(_), do: false
+
+  @doc ~S"""
+  Returns `true` if bit 0 is set to 1.
+
+  ## Examples
+
+      iex> Kadabra.Frame.Headers.end_stream?(<<0::7, 1::1>>)
+      true
+
+      iex> Kadabra.Frame.Headers.end_stream?(<<0::8>>)
+      false
+  """
+  def end_stream?(<<_::7, 1::1>>), do: true
+  def end_stream?(_), do: false
+end

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -1,0 +1,33 @@
+defmodule Kadabra.Frame.Ping do
+  defstruct [:data, ack: false]
+
+  alias Kadabra.Http2
+
+  def new do
+    %__MODULE__{
+      data: <<0, 0, 0, 0, 0, 0, 0, 0>>,
+      ack: false
+    }
+  end
+
+  def new(%{payload: data, flags: flags}) do
+    %__MODULE__{
+      data: data,
+      ack: (flags == 0x1)
+    }
+  end
+
+  def new(opts) do
+    %__MODULE__{
+      data: opts[:data],
+      ack: opts[:ack]
+    }
+  end
+
+  def ack_flag(%{ack: true}), do: 0x1
+  def ack_flag(%{ack: false}), do: 0x0
+
+  def to_bin(frame) do
+    Http2.build_frame(0x6, ack_flag(frame), 0x0, frame.data)
+  end
+end

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -1,7 +1,7 @@
 defmodule Kadabra.Frame.Ping do
   defstruct [:data, ack: false]
 
-  alias Kadabra.Http2
+  alias Kadabra.{Frame, Http2}
   alias Kadabra.Frame.Flags
 
   def new do
@@ -11,7 +11,7 @@ defmodule Kadabra.Frame.Ping do
     }
   end
 
-  def new(%{payload: data, flags: flags}) do
+  def new(%Frame{type: 0x6, payload: data, flags: flags}) do
     %__MODULE__{
       data: data,
       ack: Flags.ack?(flags)
@@ -29,6 +29,7 @@ defmodule Kadabra.Frame.Ping do
   def ack_flag(%{ack: false}), do: 0x0
 
   def to_bin(frame) do
-    Http2.build_frame(0x6, ack_flag(frame), 0x0, frame.data)
+    ack = if frame.ack, do: Flags.ack, else: 0x0
+    Http2.build_frame(0x6, ack, 0x0, frame.data)
   end
 end

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -2,6 +2,7 @@ defmodule Kadabra.Frame.Ping do
   defstruct [:data, ack: false]
 
   alias Kadabra.Http2
+  alias Kadabra.Frame.Flags
 
   def new do
     %__MODULE__{
@@ -13,7 +14,7 @@ defmodule Kadabra.Frame.Ping do
   def new(%{payload: data, flags: flags}) do
     %__MODULE__{
       data: data,
-      ack: (flags == 0x1)
+      ack: Flags.ack?(flags)
     }
   end
 

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -27,9 +27,11 @@ defmodule Kadabra.Frame.Ping do
 
   def ack_flag(%{ack: true}), do: 0x1
   def ack_flag(%{ack: false}), do: 0x0
+end
 
+defimpl Kadabra.Encodable, for: Kadabra.Frame.Ping do
   def to_bin(frame) do
     ack = if frame.ack, do: Flags.ack, else: 0x0
-    Http2.build_frame(0x6, ack, 0x0, frame.data)
+    Kadabra.Http2.build_frame(0x6, ack, 0x0, frame.data)
   end
 end

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -1,7 +1,7 @@
 defmodule Kadabra.Frame.Ping do
   defstruct [:data, ack: false]
 
-  alias Kadabra.{Frame, Http2}
+  alias Kadabra.Frame
   alias Kadabra.Frame.Flags
 
   def new do
@@ -30,8 +30,11 @@ defmodule Kadabra.Frame.Ping do
 end
 
 defimpl Kadabra.Encodable, for: Kadabra.Frame.Ping do
+  alias Kadabra.Http2
+  alias Kadabra.Frame.Flags
+
   def to_bin(frame) do
     ack = if frame.ack, do: Flags.ack, else: 0x0
-    Kadabra.Http2.build_frame(0x6, ack, 0x0, frame.data)
+    Http2.build_frame(0x6, ack, 0x0, frame.data)
   end
 end

--- a/lib/frame/priority.ex
+++ b/lib/frame/priority.ex
@@ -1,0 +1,23 @@
+defmodule Kadabra.Frame.Priority do
+  defstruct [:stream_dependency, :weight, exclusive: false]
+
+  def new(%{} = frame) do
+    case parse_payload(frame.payload) do
+      {:ok, e, dep, weight} ->
+        %__MODULE__{
+          exclusive: (e == 1),
+          stream_dependency: dep,
+          weight: weight 
+        }
+      {:error, payload} ->
+        {:error, frame}
+    end
+  end
+
+  defp parse_payload(<<e::1, dep::31, weight::8>>) do
+    {:ok, e, dep, weight}
+  end
+  defp parse_payload(payload) do
+    {:error, payload}
+  end
+end

--- a/lib/frame/priority.ex
+++ b/lib/frame/priority.ex
@@ -18,7 +18,7 @@ defmodule Kadabra.Frame.Priority do
           stream_dependency: dep,
           weight: weight
         }
-      {:error, payload} ->
+      {:error, _payload} ->
         {:error, frame}
     end
   end

--- a/lib/frame/priority.ex
+++ b/lib/frame/priority.ex
@@ -1,13 +1,22 @@
 defmodule Kadabra.Frame.Priority do
   defstruct [:stream_dependency, :weight, exclusive: false]
 
-  def new(%{} = frame) do
-    case parse_payload(frame.payload) do
+  alias Kadabra.Frame
+
+  @type t :: %__MODULE__{
+    exclusive: boolean,
+    stream_dependency: non_neg_integer,
+    weight: integer
+  }
+
+  @spec new(Frame.t) :: {:ok, t} | {:error, Frame.t}
+  def new(%Frame{payload: payload} = frame) do
+    case parse_payload(payload) do
       {:ok, e, dep, weight} ->
         %__MODULE__{
-          exclusive: (e == 1),
+          exclusive: (e == 0x1),
           stream_dependency: dep,
-          weight: weight 
+          weight: weight
         }
       {:error, payload} ->
         {:error, frame}

--- a/lib/frame/push_promise.ex
+++ b/lib/frame/push_promise.ex
@@ -1,3 +1,29 @@
 defmodule Kadabra.Frame.PushPromise do
-  defstruct [:stream_id, :headers, end_headers: false]
+  defstruct [:stream_id, :header_block_fragment, end_headers: false]
+
+  def new(%{payload: <<_::1, stream_id::31, headers::bitstring>>,
+            flags: flags}) do
+
+    %__MODULE__{
+      stream_id: stream_id,
+      header_block_fragment: headers,
+      end_headers: (flags == 0x4) 
+    }
+  end
+
+  def new(<<payload_size::24,
+            frame_type::8,
+            flags::8,
+            _::1,
+            _stream_id::31,
+            _::1,
+            stream_id::31,
+            headers::bitstring>> = bin) do
+
+    %__MODULE__{
+      stream_id: stream_id,
+      header_block_fragment: headers,
+      end_headers: (flags == 0x4) 
+    }
+  end
 end

--- a/lib/frame/push_promise.ex
+++ b/lib/frame/push_promise.ex
@@ -1,13 +1,15 @@
 defmodule Kadabra.Frame.PushPromise do
   defstruct [:stream_id, :header_block_fragment, end_headers: false]
 
+  alias Kadabra.Frame.Flags
+
   def new(%{payload: <<_::1, stream_id::31, headers::bitstring>>,
             flags: flags}) do
 
     %__MODULE__{
       stream_id: stream_id,
       header_block_fragment: headers,
-      end_headers: (flags == 0x4) 
+      end_headers: Flags.end_headers?(flags)
     }
   end
 
@@ -23,7 +25,7 @@ defmodule Kadabra.Frame.PushPromise do
     %__MODULE__{
       stream_id: stream_id,
       header_block_fragment: headers,
-      end_headers: (flags == 0x4) 
+      end_headers: Flags.end_headers?(flags)
     }
   end
 end

--- a/lib/frame/push_promise.ex
+++ b/lib/frame/push_promise.ex
@@ -13,14 +13,14 @@ defmodule Kadabra.Frame.PushPromise do
     }
   end
 
-  def new(<<payload_size::24,
-            frame_type::8,
+  def new(<<_payload_size::24,
+            _frame_type::8,
             flags::8,
             _::1,
             _stream_id::31,
             _::1,
             stream_id::31,
-            headers::bitstring>> = bin) do
+            headers::bitstring>>) do
 
     %__MODULE__{
       stream_id: stream_id,

--- a/lib/frame/push_promise.ex
+++ b/lib/frame/push_promise.ex
@@ -1,0 +1,3 @@
+defmodule Kadabra.Frame.PushPromise do
+  defstruct [:stream_id, :headers, end_headers: false]
+end

--- a/lib/frame/rst_stream.ex
+++ b/lib/frame/rst_stream.ex
@@ -1,7 +1,7 @@
 defmodule Kadabra.Frame.RstStream do
   defstruct [:stream_id, :error_code]
 
-  alias Kadabra.{Error, Frame, Http2}
+  alias Kadabra.{Error, Frame}
 
   @type t :: %__MODULE__{
     error_code: <<_::32>>,
@@ -23,7 +23,9 @@ defmodule Kadabra.Frame.RstStream do
 end
 
 defimpl Kadabra.Encodable, for: Kadabra.Frame.RstStream do
+  alias Kadabra.Http2
+
   def to_bin(frame) do
-    Kadabra.Http2.build_frame(0x3, 0x0, frame.stream_id, frame.error_code)
+    Http2.build_frame(0x3, 0x0, frame.stream_id, frame.error_code)
   end
 end

--- a/lib/frame/rst_stream.ex
+++ b/lib/frame/rst_stream.ex
@@ -20,8 +20,10 @@ defmodule Kadabra.Frame.RstStream do
       error_code: error_code
     }
   end
+end
 
+defimpl Kadabra.Encodable, for: Kadabra.Frame.RstStream do
   def to_bin(frame) do
-    Http2.build_frame(0x3, 0x0, frame.stream_id, frame.error_code)
+    Kadabra.Http2.build_frame(0x3, 0x0, frame.stream_id, frame.error_code)
   end
 end

--- a/lib/frame/rst_stream.ex
+++ b/lib/frame/rst_stream.ex
@@ -1,0 +1,20 @@
+defmodule Kadabra.Frame.RstStream do
+  defstruct [:stream_id, :error_code]
+
+  alias Kadabra.{Error, Http2}
+
+  def new(stream_id) when is_integer(stream_id) do
+    %__MODULE__{stream_id: stream_id, error_code: Error.no_error}
+  end
+
+  def new(%{stream_id: stream_id, payload: error_code}) do
+    %__MODULE__{
+      stream_id: stream_id,
+      error_code: error_code
+    }
+  end
+
+  def to_bin(frame) do
+    Http2.build_frame(0x3, 0x0, frame.stream_id, frame.error_code)
+  end
+end

--- a/lib/frame/rst_stream.ex
+++ b/lib/frame/rst_stream.ex
@@ -1,12 +1,19 @@
 defmodule Kadabra.Frame.RstStream do
   defstruct [:stream_id, :error_code]
 
-  alias Kadabra.{Error, Http2}
+  alias Kadabra.{Error, Frame, Http2}
 
+  @type t :: %__MODULE__{
+    error_code: <<_::32>>,
+    stream_id: non_neg_integer
+  }
+
+  @spec new(non_neg_integer) :: t
   def new(stream_id) when is_integer(stream_id) do
     %__MODULE__{stream_id: stream_id, error_code: Error.no_error}
   end
 
+  @spec new(Frame.t) :: t
   def new(%{stream_id: stream_id, payload: error_code}) do
     %__MODULE__{
       stream_id: stream_id,

--- a/lib/frame/settings.ex
+++ b/lib/frame/settings.ex
@@ -1,0 +1,35 @@
+defmodule Kadabra.Frame.Settings do
+  defstruct [:settings, ack: false]
+
+  alias Kadabra.Connection
+
+  def new(%{payload: p, flags: flags}) do
+    s_list = parse_settings(p)
+    case put_settings(%Connection.Settings{}, s_list) do
+      {:ok, settings} ->
+        {:ok, %__MODULE__{settings: settings, ack: ack?(flags)}}
+      {:error, code, settings} -> {:error, code}
+    end
+  end
+
+  def ack?(1), do: true
+  def ack?(0), do: false
+
+  def parse(payload) do
+    settings = %Connection.Settings{}
+  end
+
+  def parse_settings(<<>>), do: []
+  def parse_settings(bin) do
+    <<identifier::16, value::32, rest::bitstring>> = bin
+    [{identifier, value}] ++ parse_settings(rest)
+  end
+
+  def put_settings(settings, []), do: {:ok, settings}
+  def put_settings(settings, [{ident, value} | rest]) do
+    case Connection.Settings.put(settings, ident, value) do
+      {:ok, settings} -> put_settings(settings, rest)
+      {:error, code, settings} -> {:error, code, settings}
+    end
+  end
+end

--- a/lib/frame/settings.ex
+++ b/lib/frame/settings.ex
@@ -8,16 +8,12 @@ defmodule Kadabra.Frame.Settings do
     case put_settings(%Connection.Settings{}, s_list) do
       {:ok, settings} ->
         {:ok, %__MODULE__{settings: settings, ack: ack?(flags)}}
-      {:error, code, settings} -> {:error, code}
+      {:error, code, _settings} -> {:error, code}
     end
   end
 
   def ack?(1), do: true
   def ack?(0), do: false
-
-  def parse(payload) do
-    settings = %Connection.Settings{}
-  end
 
   def parse_settings(<<>>), do: []
   def parse_settings(bin) do

--- a/lib/frame/settings.ex
+++ b/lib/frame/settings.ex
@@ -2,12 +2,13 @@ defmodule Kadabra.Frame.Settings do
   defstruct [:settings, ack: false]
 
   alias Kadabra.Connection
+  alias Kadabra.Frame.Flags
 
   def new(%{payload: p, flags: flags}) do
     s_list = parse_settings(p)
     case put_settings(%Connection.Settings{}, s_list) do
       {:ok, settings} ->
-        {:ok, %__MODULE__{settings: settings, ack: ack?(flags)}}
+        {:ok, %__MODULE__{settings: settings, ack: Flags.ack?(flags)}}
       {:error, code, _settings} -> {:error, code}
     end
   end

--- a/lib/frame/window_update.ex
+++ b/lib/frame/window_update.ex
@@ -1,7 +1,15 @@
 defmodule Kadabra.Frame.WindowUpdate do
   defstruct [:stream_id, :window_size_increment]
 
-  def new(%{payload: p, stream_id: stream_id}) do
+  alias Kadabra.Frame
+
+  @type t :: %__MODULE__{
+    stream_id: non_neg_integer,
+    window_size_increment: non_neg_integer
+  }
+
+  @spec new(Frame.t) :: t
+  def new(%Frame{payload: p, stream_id: stream_id}) do
     %__MODULE__{
       window_size_increment: p,
       stream_id: stream_id

--- a/lib/frame/window_update.ex
+++ b/lib/frame/window_update.ex
@@ -1,0 +1,10 @@
+defmodule Kadabra.Frame.WindowUpdate do
+  defstruct [:stream_id, :window_size_increment]
+
+  def new(%{payload: p, stream_id: stream_id}) do
+    %__MODULE__{
+      window_size_increment: p,
+      stream_id: stream_id
+    }
+  end
+end

--- a/lib/http2.ex
+++ b/lib/http2.ex
@@ -1,6 +1,6 @@
 defmodule Kadabra.Http2 do
   @moduledoc """
-    Handles all HTTP2 connection, request and response functions.
+  Handles all HTTP2 connection, request and response functions.
   """
   require Logger
 

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -46,7 +46,7 @@ defmodule Kadabra do
         == Streams ==
         #{stream_data}
         """
-        |> Pane.console
+        |> IO.puts
       _else -> :error
     end
   end

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -19,7 +19,7 @@ defmodule Kadabra do
 
   def ping(pid), do: GenServer.cast(pid, {:send, :ping})
 
-  def info(pid, opts \\ []) do
+  def info(pid, _opts \\ []) do
     case GenServer.call(pid, :get_info) do
       {:ok, info} ->
         # width = opts[:width] || 120

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -22,16 +22,16 @@ defmodule Kadabra do
   def info(pid, opts \\ []) do
     case GenServer.call(pid, :get_info) do
       {:ok, info} ->
-        width = opts[:width] || 120
-        headers = opts[:data] || [:id, :status, :headers, :body]
-        stream_table_opts = [width: width, data: headers]
+        # width = opts[:width] || 120
+        # headers = opts[:data] || [:id, :status, :headers, :body]
+        # stream_table_opts = [width: width, data: headers]
 
-        stream_data =
-          info.streams
-          |> Map.values
-          |> Enum.map(& Map.put(&1, :body, String.slice(&1.body, 0..40)))
-          |> Enum.sort_by(& &1.id)
-          |> Scribe.format(stream_table_opts)
+        # stream_data =
+        #   info.streams
+        #   |> Map.values
+        #   |> Enum.map(& Map.put(&1, :body, String.slice(&1.body, 0..40)))
+        #   |> Enum.sort_by(& &1.id)
+        #   |> Scribe.format(stream_table_opts)
 
         """
 
@@ -43,8 +43,6 @@ defmodule Kadabra do
         Next Available Stream ID: #{info.stream_id}
         Buffer: #{inspect(info.buffer)}
 
-        == Streams ==
-        #{stream_data}
         """
         |> IO.puts
       _else -> :error

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -6,11 +6,8 @@ defmodule Kadabra do
 
   def open(uri, scheme, opts \\ []) do
     port = opts[:port] || 443
-    nopts = List.keydelete opts, :port, 0
-    case Connection.start_link(uri, self(), scheme: scheme, ssl: nopts, port: port) do
-      {:ok, pid} -> {:ok, pid}
-      {:error, reason} -> {:error, reason}
-    end
+    nopts = List.keydelete(opts, :port, 0)
+    Connection.start_link(uri, self(), scheme: scheme, ssl: nopts, port: port)
   end
 
   def close(pid), do: GenServer.cast(pid, {:send, :goaway})

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -5,7 +5,7 @@ defmodule Kadabra.Stream do
   defstruct [:id, :headers, :uri, :connection, :decoder, :encoder,
              :socket, body: "", scheme: :https]
 
-  alias Kadabra.{Connection, Http2, Stream}
+  alias Kadabra.{Connection, Encodable, Http2, Stream}
   alias Kadabra.Frame.{Continuation, Data, Headers, PushPromise, RstStream}
 
   @data 0x0
@@ -43,7 +43,7 @@ defmodule Kadabra.Stream do
   end
 
   def handle_event(:enter, _old, @half_closed_remote, stream) do
-    bin = stream.id |> RstStream.new |> RstStream.to_bin
+    bin = stream.id |> RstStream.new |> Encodable.to_bin
     :ssl.send(stream.socket, bin)
 
     :gen_statem.cast(self(), :close)

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -2,5 +2,114 @@ defmodule Kadabra.Stream do
   @moduledoc """
   Struct returned from open connections.
   """
-  defstruct id: nil, headers: nil, body: nil, status: nil
+  defstruct id: nil,
+            headers: nil,
+            body: nil,
+            uri: nil,
+            scheme: :https,
+            connection: nil,
+            decoder: nil,
+            encoder: nil,
+            socket: nil
+
+  alias Kadabra.{Http2, Stream}
+
+  @data 0x0
+  @headers 0x1
+  @rst_stream 0x3
+  @settings 0x4
+  @ping 0x6
+  @goaway 0x7
+  @window_update 0x8
+
+  @closed :closed
+  @half_closed_local :half_closed_local
+  @half_closed_remote :half_closed_remote
+  @idle :idle
+  @open :open
+  @reserved_local :reserved_local
+  @reserved_remote :reserved_remote
+
+  def start_link(stream) do
+    :gen_statem.start_link(__MODULE__, stream, name: name(stream))
+  end
+
+  def name(stream) do
+    {:via, Registry, {Registry.Kadabra, {stream.uri, stream.id}}}
+  end
+
+  def handle_event(:enter, _old, @half_closed_remote, stream) do
+    # TODO: send ES here
+    :gen_statem.cast(self(), :close)
+    {:keep_state, stream}
+  end
+  def handle_event(:enter, _old, @closed, stream) do
+    send(stream.connection, {:finished, Stream.Response.new(stream)})
+    {:keep_state, stream}
+  end
+  def handle_event(:enter, _old, _new, stream), do: {:keep_state, stream}
+
+  def handle_event(:cast, :close, _state, stream) do
+    {:next_state, @closed, stream}
+  end
+
+  def handle_event(:cast, {:recv_headers, %{flags: flags, payload: payload}}, state, stream) do
+    headers = HPack.decode(payload, stream.decoder)
+    stream = %Stream{stream | headers: headers}
+
+    case flags do
+      0x5 -> {:next_state, @half_closed_remote, stream}
+      _ -> {:keep_state, stream}
+    end
+  end
+
+  def handle_event(:cast, {:recv_data, %{flags: flags, payload: payload} = frame}, state, stream) do
+    body = stream.body || ""
+    stream = %Stream{stream | body: body <> payload}
+    case flags do
+      0x1 -> {:next_state, @half_closed_remote, stream}
+      _ -> {:keep_state, stream}
+    end
+  end
+
+  def handle_event(:cast, {:recv_rst_stream, frame}, state, stream)
+    when state in [@open, @half_closed_local, @half_closed_remote] do
+    {:next_state, :closed, stream}
+  end
+
+  def handle_event(:cast, {:send_headers, headers, payload}, state, stream) do
+    headers = add_headers(headers, stream)
+    encoded = HPack.encode(headers, stream.encoder)
+    headers_payload = :erlang.iolist_to_binary(encoded)
+    h = Http2.build_frame(@headers, 0x4, stream.id, headers_payload)
+
+    :ssl.send(stream.socket, h)
+
+    if payload do
+      h_p = Http2.build_frame(@data, 0x1, stream.id, payload)
+      :ssl.send(stream.socket, h_p)
+    end
+
+    {:next_state, @open, stream}
+  end
+
+  defp add_headers(headers, stream) do
+    h = headers ++
+    [
+      {":scheme", Atom.to_string(stream.scheme)},
+      {":authority", List.to_string(stream.uri)}
+    ]
+    # sorting headers to have pseudo headers first.
+    Enum.sort(h, fn({a, b}, {c, d}) -> a < c end)
+  end
+
+  def init(stream) do
+    {:ok, @idle, stream}
+  end
+
+  def callback_mode, do: [:handle_event_function, :state_enter]
+
+  def terminate(_reason, _state, _data), do: :void
+
+  def code_change(_vsn, state, data, _extra), do: {:ok, state, data}
 end

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -10,11 +10,6 @@ defmodule Kadabra.Stream do
 
   @data 0x0
   @headers 0x1
-  # @rst_stream 0x3
-  # @settings 0x4
-  # @ping 0x6
-  # @goaway 0x7
-  # @window_update 0x8
 
   @closed :closed
   @half_closed_local :half_closed_local
@@ -136,9 +131,7 @@ defmodule Kadabra.Stream do
     Enum.sort(h, fn({a, _b}, {c, _d}) -> a < c end)
   end
 
-  def init(stream) do
-    {:ok, @idle, stream}
-  end
+  def init(stream), do: {:ok, @idle, stream}
 
   def callback_mode, do: [:handle_event_function, :state_enter]
 

--- a/lib/stream/response.ex
+++ b/lib/stream/response.ex
@@ -21,15 +21,16 @@ defmodule Kadabra.Stream.Response do
     }
   end
 
-  defp get_status(headers) do
-    result =
-      headers
-      |> Enum.filter(& &1 != :undefined)
-      |> Enum.find(fn({key, _val}) -> key == ":status" end)
-
-    case result do
+  def get_status(headers) do
+    case get_header(headers, ":status") do
       {":status", status} -> status |> String.to_integer
       nil -> nil
     end
+  end
+
+  def get_header(headers, header) do
+    headers
+    |> Enum.filter(& &1 != :undefined)
+    |> Enum.find(fn({key, _val}) -> key == header end)
   end
 end

--- a/lib/stream/response.ex
+++ b/lib/stream/response.ex
@@ -1,0 +1,22 @@
+defmodule Kadabra.Stream.Response do
+  @moduledoc """
+  Struct returned from open connections.
+  """
+  defstruct id: nil, headers: nil, body: nil, status: nil
+
+  def new(%Kadabra.Stream{id: id, headers: headers, body: body}) do
+    %__MODULE__{
+      id: id,
+      headers: headers,
+      body: body,
+      status: get_status(headers)
+    }
+  end
+
+  defp get_status(headers) do
+    case Enum.find(headers, fn({key, _val}) -> key == ":status" end) do
+      {":status", status} -> status |> String.to_integer
+      nil -> nil
+    end
+  end
+end

--- a/lib/stream/response.ex
+++ b/lib/stream/response.ex
@@ -22,7 +22,12 @@ defmodule Kadabra.Stream.Response do
   end
 
   defp get_status(headers) do
-    case Enum.find(headers, fn({key, _val}) -> key == ":status" end) do
+    result =
+      headers
+      |> Enum.filter(& &1 != :undefined)
+      |> Enum.find(fn({key, _val}) -> key == ":status" end)
+
+    case result do
       {":status", status} -> status |> String.to_integer
       nil -> nil
     end

--- a/lib/stream/response.ex
+++ b/lib/stream/response.ex
@@ -2,8 +2,16 @@ defmodule Kadabra.Stream.Response do
   @moduledoc """
   Struct returned from open connections.
   """
-  defstruct id: nil, headers: nil, body: nil, status: nil
+  defstruct [:id, :headers, :body, :status]
 
+  @type t :: %__MODULE__{
+    id: integer,
+    headers: Keyword.t,
+    body: String.t,
+    status: integer
+  }
+
+  @spec new(%Kadabra.Stream{}) :: t
   def new(%Kadabra.Stream{id: id, headers: headers, body: body}) do
     %__MODULE__{
       id: id,

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,10 @@ defmodule Kadabra.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :hpack]]
+    [
+      applications: [:logger, :hpack],
+      mod: {Kadabra.Application, []}
+    ]
   end
 
   defp description do

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Kadabra.Mixfile do
   def project do
     [
       app: :kadabra,
-      version: "0.2.0",
-      elixir: "~> 1.3",
+      version: "0.3.0",
+      elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),
@@ -14,7 +14,8 @@ defmodule Kadabra.Mixfile do
       description: description(),
       source_url: "https://github.com/codedge-llc/kadabra",
       docs: [main: "readme",
-             extras: ["README.md"]]
+             extras: ["README.md"]],
+      dialyzer: [plt_add_deps: true, plt_add_apps: [:ssl]]
     ]
   end
 
@@ -37,6 +38,7 @@ defmodule Kadabra.Mixfile do
       {:scribe, "~> 0.4"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:dogma, "~> 0.1", only: :dev},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Kadabra.Mixfile do
       {:scribe, "~> 0.4"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:dogma, "~> 0.1", only: :dev},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      #{:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Kadabra.Mixfile do
       {:scribe, "~> 0.4"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:dogma, "~> 0.1", only: :dev},
-      #{:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -1,0 +1,16 @@
+defmodule Kadabra.ConnectionTest do
+  use ExUnit.Case
+
+  test "reconnects SSL socket automatically if disconnected" do
+    uri = 'http2.golang.org'
+    {:ok, pid} = Kadabra.open(uri, :https)
+
+    %{socket: socket} = :sys.get_state(pid)
+    :ssl.close(socket) 
+    send(pid, {:ssl_closed, socket}) # Why does close/1 not send this?
+
+    Kadabra.ping(pid)
+
+    assert_receive {:pong, _pid}, 5_000
+  end
+end

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -1,0 +1,4 @@
+defmodule Kadabra.ErrorTest do
+  use ExUnit.Case
+  doctest Kadabra.Error
+end

--- a/test/frame/continuation_test.exs
+++ b/test/frame/continuation_test.exs
@@ -1,0 +1,4 @@
+defmodule Kadabra.Frame.ContinuationTest do
+  use ExUnit.Case
+  doctest Kadabra.Frame.Continuation
+end

--- a/test/frame/flags_test.exs
+++ b/test/frame/flags_test.exs
@@ -1,0 +1,4 @@
+defmodule Kadabra.Frame.FlagsTest do
+  use ExUnit.Case
+  doctest Kadabra.Frame.Flags
+end

--- a/test/frame/headers_test.exs
+++ b/test/frame/headers_test.exs
@@ -1,0 +1,4 @@
+defmodule Kadabra.Frame.HeadersTest do
+  use ExUnit.Case
+  doctest Kadabra.Frame.Headers
+end

--- a/test/kadabra_test.exs
+++ b/test/kadabra_test.exs
@@ -33,6 +33,21 @@ defmodule KadabraTest do
         status: ^expected_status
       }}, 5_000
     end
+
+    test "https://http2.golang.org/file/gopher.png" do
+      uri = 'http2.golang.org'
+      {:ok, pid} = Kadabra.open(uri, :https)
+      Kadabra.get(pid, "/file/gopher.png")
+
+      receive do
+        {:end_stream, response} ->
+          assert response.id == 1
+          assert response.status == 200
+          assert byte_size(response.body) == 17668
+      after 5_000 ->
+        flunk "No stream response received."
+      end
+    end
   end
 
   describe "PUT" do

--- a/test/kadabra_test.exs
+++ b/test/kadabra_test.exs
@@ -48,6 +48,21 @@ defmodule KadabraTest do
         flunk "No stream response received."
       end
     end
+
+    test "https://http2.golang.org/serverpush" do
+      uri = 'http2.golang.org'
+      {:ok, pid} = Kadabra.open(uri, :https)
+      Kadabra.get(pid, "/serverpush")
+
+      receive do
+        {:push_promise, response} ->
+          assert response.id == 2
+          refute response.status
+          assert Stream.Response.get_header(response.headers, ":path")
+      after 5_000 ->
+        flunk "No push promise received."
+      end
+    end
   end
 
   describe "PUT" do

--- a/test/kadabra_test.exs
+++ b/test/kadabra_test.exs
@@ -2,7 +2,7 @@ defmodule KadabraTest do
   use ExUnit.Case
   doctest Kadabra
 
-  alias Kadabra.{Stream}
+  alias Kadabra.Stream
 
   describe "GET"  do
     test "https://http2.golang.org/reqinfo" do
@@ -10,7 +10,7 @@ defmodule KadabraTest do
       {:ok, pid} = Kadabra.open(uri, :https)
       Kadabra.get(pid, "/reqinfo")
 
-      assert_receive {:end_stream, %Stream{
+      assert_receive {:end_stream, %Stream.Response{
         id: 1,
         headers: _headers,
         body: _body,
@@ -26,7 +26,7 @@ defmodule KadabraTest do
       expected_body = "<a href=\"/\">Found</a>.\n\n"
       expected_status = 302
 
-      assert_receive {:end_stream, %Stream{
+      assert_receive {:end_stream, %Stream.Response{
         id: 1,
         headers: _headers,
         body: ^expected_body,
@@ -44,7 +44,7 @@ defmodule KadabraTest do
 
       expected_body = String.upcase(payload)
 
-      assert_receive {:end_stream, %Stream{
+      assert_receive {:end_stream, %Stream.Response{
         id: 1,
         headers: _headers,
         body: ^expected_body,
@@ -60,7 +60,7 @@ defmodule KadabraTest do
 
       expected_body = "bytes=4, CRC32=d87f7e0c"
 
-      assert_receive {:end_stream, %Stream{
+      assert_receive {:end_stream, %Stream.Response{
         id: 1,
         headers: _headers,
         body: ^expected_body,


### PR DESCRIPTION
@cstar Took a crack at the `:gen_statem` implementation myself. Was surprisingly easy to implement with a Registry.

Each stream is spawned with a reference to the original `Kadabra.Connection` and it's ssl socket. I'm guessing a restarted socket will need to be propagated across all of the active streams?

Also worth considering.. this would bump minimum requirements up to Elixir 1.4 and OTP 19.