### PR TITLE
Reconnect automatically to server

### DIFF
--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -22,14 +22,15 @@ defmodule Kadabra.Connection do
   def init({:ok, uri, pid, opts}) do
     case do_connect(uri, opts) do
       {:ok, socket} ->
-        {:ok, initial_state(socket, uri, pid, opts)}
+        state = initial_state(socket, uri, pid, opts)
+        {:ok, state}
       {:error, error} ->
         Logger.error(inspect(error))
         {:error, error}
     end
   end
 
-  defp initial_state(socket, uri, pid, opts) do
+  defp initial_state(socket, uri, pid, opts, stream_id \\ 1, streams \\ %{}) do
    {:ok, encoder} =  HPack.Table.start_link(1000)
    {:ok, decoder} =  HPack.Table.start_link(1000)
    %{
@@ -37,9 +38,11 @@ defmodule Kadabra.Connection do
       client: pid,
       uri: uri,
       scheme: opts[:scheme] || :https,
+      opts: opts,
       socket: socket,
-      stream_id: 1,
-      streams: %{},
+      stream_id: stream_id,
+      streams: streams,
+      reconnect: opts[:reconnect] || :true,
       encoder_state: encoder,
       decoder_state: decoder
     }
@@ -65,7 +68,7 @@ defmodule Kadabra.Connection do
   defp ssl_options(nil), do: ssl_options([])
   defp ssl_options(opts) do
     opts ++ [
-      {:active, true},
+      {:active, :once},
       {:packet, :raw},
       {:reuseaddr, false},
       {:alpn_advertised_protocols, [<<"h2">>]},
@@ -124,8 +127,7 @@ defmodule Kadabra.Connection do
   end
 
   def handle_cast({:recv, :rst_stream, frame}, state) do
-    do_recv_rst_stream(frame, state)
-    {:noreply, state}
+    {:noreply, do_recv_rst_stream(frame, state)}
   end
 
   def handle_cast({:recv, :window_update, %{stream_id: _stream_id,
@@ -144,9 +146,12 @@ defmodule Kadabra.Connection do
     body = stream.body || ""
     stream = %Stream{ stream | body: body <> frame[:payload] }
 
-    if frame[:flags] == 0x1, do: send pid, {:end_stream, stream}
-
-    put_stream(stream_id, state, stream)
+    if frame[:flags] == 0x1 do
+     send pid, {:end_stream, stream}
+     remove_stream(state, stream_id)
+    else
+      put_stream(stream_id, state, stream)
+    end
   end
 
   defp do_recv_headers(%{stream_id: stream_id,
@@ -161,9 +166,12 @@ defmodule Kadabra.Connection do
       |> String.to_integer
     stream = %Stream{ stream | headers: headers, status: status }
 
-    if flags == 0x5, do: send pid, {:end_stream, stream}
-
-    put_stream(stream_id, state, stream)
+    if flags == 0x5 do 
+     send pid, {:end_stream, stream}
+     remove_stream(state, stream_id)
+    else
+      put_stream(stream_id, state, stream)
+    end
   end
 
   defp do_send_headers(headers, payload, %{socket: socket,
@@ -192,7 +200,7 @@ defmodule Kadabra.Connection do
       {":authority", List.to_string(uri)}
     ]
     # sorting headers to have pseudo headers first.
-    Enum.sort(h, fn({a, b}, {c, d}) -> a < c end)
+    Enum.sort(h, fn({a, _b}, {c, _d}) -> a < c end)
   end
 
   defp do_send_goaway(%{socket: socket, stream_id: stream_id}) do
@@ -205,7 +213,7 @@ defmodule Kadabra.Connection do
     log_goaway(code, last_stream_id, rest)
 
     send pid, {:closed, self()}
-    {:noreply, state}
+    {:noreply, %{state | streams: %{}}}
   end
 
   def log_goaway(code, id, bin) do
@@ -243,6 +251,7 @@ defmodule Kadabra.Connection do
     code = :binary.decode_unsigned(frame[:payload])
     _error = Error.string(code)
     send pid, {:end_stream, get_stream(frame[:stream_id], state)}
+    remove_stream(state, frame[:stream_id])
   end
 
   defp put_stream(id, state, stream) do
@@ -255,12 +264,17 @@ defmodule Kadabra.Connection do
     state[:streams][id_string] || %Kadabra.Stream{id: id}
   end
 
+  defp remove_stream %{streams: streams} = state, id do
+    id_string = Integer.to_string(id)
+    %{state | streams: Map.delete(streams, id_string) }
+  end
+
   def handle_info({:tcp, _socket, _bin}, state) do
     {:noreply, state}
   end
 
   def handle_info({:tcp_closed, _socket}, state) do
-    {:noreply, state}
+    maybe_reconnect(state)
   end
 
   def handle_info({:ssl, _socket, bin}, state) do
@@ -268,15 +282,17 @@ defmodule Kadabra.Connection do
   end
 
   def handle_info({:ssl_closed, _socket}, state) do
-    {:noreply, state}
+   maybe_reconnect(state)
   end
 
   defp do_recv_ssl(bin, %{socket: socket} = state) do
     bin = state[:buffer] <> bin
     case parse_ssl(socket, bin, state) do
       :ok ->
+        :ssl.setopts(socket, [{:active, :once}])
         {:noreply, %{state | buffer: ""}}
       {:error, bin} ->
+        :ssl.setopts(socket, [{:active, :once}])
         {:noreply, %{state | buffer: bin}}
     end
   end
@@ -294,6 +310,7 @@ defmodule Kadabra.Connection do
   def handle_response(frame) when is_binary(frame) do
     Logger.info "Got binary: #{inspect(frame)}"
   end
+
   def handle_response(frame) do
     case frame[:frame_type] do
       @data ->
@@ -331,6 +348,28 @@ defmodule Kadabra.Connection do
   def parse_settings(bin) do
     <<identifier::16, value::32, rest::bitstring>> = bin
     [{settings_param(identifier), value}] ++ parse_settings(rest)
+  end
+
+  def maybe_reconnect(%{reconnect: false, client: pid} = state) do
+    Logger.debug "Socket closed, not reopening, informing client"
+    send(pid, {:closed, self()})
+    {:stop, :normal, state}
+  end
+
+  def maybe_reconnect(%{reconnect: true, uri: uri, opts: opts, client: pid} = state) do
+    case do_connect(uri, opts) do
+      {:ok, socket} ->
+        Logger.debug "Socket closed, reopened automatically"
+        state |> inspect |> Logger.info 
+        {:ok, encoder} =  HPack.Table.start_link(1000)
+        {:ok, decoder} =  HPack.Table.start_link(1000)
+        {:noreply,  %{state | encoder_state: encoder, decoder_state: decoder, socket: socket, streams: %{}}}
+      {:error, error} ->
+        Logger.error "Socket closed, reopening failed with #{error}"
+        state |> inspect |> Logger.info 
+        send(pid, :closed)
+         {:stop, :normal, state}
+    end
   end
 
   defp get_status(headers) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule Kadabra.Mixfile do
       {:hpack, "~> 1.0.0"},
       {:scribe, "~> 0.4"},
       {:ex_doc, "~> 0.14", only: :dev},
-      {:dogma, "~> 0.1", only: :dev}
+      {:dogma, "~> 0.1", only: :dev},
+      {:hpack, "~> 1.0.0"}
     ]
   end
 


### PR DESCRIPTION
This pull request adds the following features:

- send a `:closed` message when the socket is closed at TCP or SSL level when `opts[:reconnect] = :false`
or
- automatically reconnect a socket when `opts[:reconnect] = :true` (default behavior)

It also fixes a bug with the `streams` map would never be emptied.
It does not reset the stream_id, as it is used with Pigeon. It means that it can run out of stream ids.
