### PR TITLE
fix: noproc crash caused by race condition in recv GOAWAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.3.7
+- Fixed: `noproc` crash caused by race condition on recv GOAWAY
+
 ## v0.3.6
 - Fixed: ES flag properly set on certain HEADERS frames
 

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -73,7 +73,7 @@ defmodule Kadabra.Stream do
   end
 
   def close(ref, stream_id) do
-    :gen_statem.stop(via_tuple(ref, stream_id))
+    ref |> via_tuple(stream_id) |> cast_recv(:close)
   end
 
   def cast_recv(pid, frame) do
@@ -82,6 +82,10 @@ defmodule Kadabra.Stream do
 
   def cast_send(pid, frame) do
     :gen_statem.cast(pid, {:send, frame})
+  end
+
+  def recv(:close, _state, _stream) do
+    {:stop, :normal}
   end
 
   # For SETTINGS initial_window_size and max_frame_size changes

--- a/lib/stream_supervisor.ex
+++ b/lib/stream_supervisor.ex
@@ -21,11 +21,11 @@ defmodule Kadabra.StreamSupervisor do
 
   def start_stream(%{flow_control: flow, ref: ref} = conn, stream_id \\ nil) do
     stream = Stream.new(conn, flow.settings, stream_id || flow.stream_id)
-    spec = worker(Stream, [stream], start_opts())
-    Supervisor.start_child(via_tuple(ref), spec)
+    Supervisor.start_child(via_tuple(ref), [stream])
   end
 
   def init(:ok) do
-    supervise([], strategy: :one_for_all)
+    spec = worker(Stream, [], start_opts())
+    supervise([spec], strategy: :simple_one_for_one)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Kadabra.Mixfile do
   use Mix.Project
 
-  @version "0.3.6"
+  @version "0.3.7"
 
   def project do
     [

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -23,4 +23,46 @@ defmodule Kadabra.ConnectionTest do
 
     assert_receive {:pong, _pid}, 5_000
   end
+
+  test "closes active streams on recv GOAWAY" do
+    uri = 'http2.golang.org'
+    {:ok, pid} = Kadabra.open(uri, :https)
+
+    # Open two streams that send the time every second
+    Kadabra.get(pid, "/clockstream")
+    Kadabra.get(pid, "/clockstream")
+
+    {_, stream_sup_pid, _, _} =
+      pid
+      |> Supervisor.which_children
+      |> Enum.find(fn({name, _, _, _}) -> name == :stream_sup end)
+
+    {_, conn_sup_pid, _, _} =
+      pid
+      |> Supervisor.which_children
+      |> Enum.find(fn({name, _, _, _}) -> name == :connection_sup end)
+
+    {_, conn_pid, _, _} =
+      conn_sup_pid
+      |> Supervisor.which_children
+      |> Enum.find(fn({name, _, _, _}) -> name == :connection end)
+
+    # Wait to collect some data on the streams
+    Process.sleep(1_500)
+
+    assert Supervisor.count_children(stream_sup_pid).active == 2
+
+    frame = Kadabra.Frame.Goaway.new(1)
+    GenServer.cast(conn_pid, {:recv, frame})
+
+    # Give a moment to clean everything up
+    Process.sleep(500)
+
+    receive do
+      {:closed, _pid} ->
+        assert Supervisor.count_children(stream_sup_pid).active == 0
+    after
+      5_000 -> flunk "Connection did not close"
+    end
+  end
 end


### PR DESCRIPTION
Casts a message to the stream instead of calling `gen_statem.close/1`. Ignores if pid doesn't exist. Stream stops itself once cast is received.

In the event the close is received before any pending `END_STREAM` frame, the client will not be notified of stream closure. This will fixed in `v0.4` with callback functionality (which will spawn a supervised task). That said, a socket would probably not send an `END_STREAM` frame *after* a `GOAWAY`, so this may be entirely a non-issue.

StreamSupervisor is now `:simple_one_for_one` (memory leak of orphaned stream child specs otherwise)

Fixes #24 
  