### PR TITLE
fix: crashes due to missing error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixed**
+
+- Fix crashes due to missing error handling
+
 ## v0.6.0
 
 **Security**

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -56,8 +56,12 @@ defmodule Kadabra.ConnectionPool do
 
     Process.flag(:trap_exit, true)
 
-    {:ok, connection} = Connection.start_link(config)
-    {:ok, %__MODULE__{connection: connection}}
+    with {:ok, connection} <- Connection.start_link(config) do
+      {:ok, %__MODULE__{connection: connection}}
+    else
+      {:error, reason} ->
+        {:stop, reason}
+    end
   end
 
   def handle_cast({:ask, demand}, state) do

--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -38,8 +38,8 @@ defmodule Kadabra.Socket do
         socket_send(socket, connection_preface())
         {:ok, %__MODULE__{socket: socket}}
 
-      error ->
-        error
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 


### PR DESCRIPTION
A bunch of init functions were assuming that everything will always return `{:ok, result}`, which obviously is not always the case... Added simple logic to return `{:stop, reason}` instead so as to not crash the whole process tree due to `FunctionClauseError` :)