### PR TITLE
feat: add some basic telemetry event metrics and support ping payloads

### DIFF
--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -75,10 +75,6 @@ defmodule Kadabra.Connection do
     GenServer.call(pid, :close)
   end
 
-  def ping(pid) do
-    GenServer.cast(pid, {:send, :ping})
-  end
-
   def ping(pid, data) do
     GenServer.cast(pid, {:send, {:ping, data}})
   end
@@ -114,12 +110,7 @@ defmodule Kadabra.Connection do
 
   # sendf
 
-  @spec sendf(:goaway | :ping | {:ping, <<_::64>>}, t) :: {:noreply, t}
-  def sendf(:ping, %Connection{config: config} = state) do
-    Egress.send_ping(config.socket)
-    {:noreply, state}
-  end
-
+  @spec sendf(:goaway | {:ping, <<_::64>> | none}, t) :: {:noreply, t}
   def sendf({:ping, data}, %Connection{config: config} = state) do
     Egress.send_ping(config.socket, data)
     {:noreply, state}

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -79,6 +79,11 @@ defmodule Kadabra.Connection do
     GenServer.cast(pid, {:send, :ping})
   end
 
+  def ping(pid, data) do
+    GenServer.cast(pid, {:send, {:ping, data}})
+  end
+
+
   # handle_cast
 
   def handle_cast({:send, type}, state) do
@@ -109,9 +114,14 @@ defmodule Kadabra.Connection do
 
   # sendf
 
-  @spec sendf(:goaway | :ping, t) :: {:noreply, t}
+  @spec sendf(:goaway | :ping | {:ping, <<_::64>>}, t) :: {:noreply, t}
   def sendf(:ping, %Connection{config: config} = state) do
     Egress.send_ping(config.socket)
+    {:noreply, state}
+  end
+
+  def sendf({:ping, data}, %Connection{config: config} = state) do
+    Egress.send_ping(config.socket, data)
     {:noreply, state}
   end
 

--- a/lib/connection/egress.ex
+++ b/lib/connection/egress.ex
@@ -25,11 +25,6 @@ defmodule Kadabra.Connection.Egress do
     Socket.send(socket, bin)
   end
 
-  def send_ping(socket) do
-    bin = Ping.new() |> Encodable.to_bin()
-    Socket.send(socket, bin)
-  end
-
   def send_ping(socket, data) do
     bin = Ping.new(data) |> Encodable.to_bin()
     Socket.send(socket, bin)

--- a/lib/connection/egress.ex
+++ b/lib/connection/egress.ex
@@ -30,6 +30,11 @@ defmodule Kadabra.Connection.Egress do
     Socket.send(socket, bin)
   end
 
+  def send_ping(socket, data) do
+    bin = Ping.new(data) |> Encodable.to_bin()
+    Socket.send(socket, bin)
+  end
+
   def send_local_settings(socket, settings) do
     bin =
       %Frame.Settings{settings: settings}

--- a/lib/connection/processor.ex
+++ b/lib/connection/processor.ex
@@ -178,8 +178,8 @@ defmodule Kadabra.Connection.Processor do
     {:ok, state}
   end
 
-  def process(%Ping{ack: true}, %{config: config} = state) do
-    Kernel.send(config.client, {:pong, self()})
+  def process(%Ping{ack: true, data: data}, %{config: config} = state) do
+    Kernel.send(config.client, {:pong, self(), data})
     {:ok, state}
   end
 

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -45,7 +45,6 @@ defmodule Kadabra.ConnectionPool do
     GenServer.call(pid, {:request, [request]})
   end
 
-  def ping(pid), do: GenServer.call(pid, :ping)
   def ping(pid, data), do: GenServer.call(pid, {:ping, data})
 
   def close(pid), do: GenServer.call(pid, :close)
@@ -73,11 +72,6 @@ defmodule Kadabra.ConnectionPool do
   def handle_call(:close, _from, state) do
     Connection.close(state.connection)
     {:stop, :shutdown, :ok, state}
-  end
-
-  def handle_call(:ping, _from, state) do
-    Connection.ping(state.connection)
-    {:reply, :ok, state}
   end
 
   def handle_call({:ping, data}, _from, state) do

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -46,6 +46,7 @@ defmodule Kadabra.ConnectionPool do
   end
 
   def ping(pid), do: GenServer.call(pid, :ping)
+  def ping(pid, data), do: GenServer.call(pid, {:ping, data})
 
   def close(pid), do: GenServer.call(pid, :close)
 
@@ -76,6 +77,11 @@ defmodule Kadabra.ConnectionPool do
 
   def handle_call(:ping, _from, state) do
     Connection.ping(state.connection)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:ping, data}, _from, state) do
+    Connection.ping(state.connection, data)
     {:reply, :ok, state}
   end
 

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -19,6 +19,8 @@ defmodule Kadabra.Frame.Ping do
   Returns new unacked ping frame. Optionally takes a payload of 8 bytes, which
   can be used to help calculate RTT times of pings that your application sends.
 
+  Can also be used to initialize a new `Frame.Ping` given a `Frame`.
+
   ## Examples
 
       iex> Kadabra.Frame.Ping.new
@@ -27,8 +29,13 @@ defmodule Kadabra.Frame.Ping do
       iex> Kadabra.Frame.Ping.new(payload: <<1, 2, 3, 4, 5, 6, 7, 8>>)
       %Kadabra.Frame.Ping{data: <<1, 2, 3, 4, 5, 6, 7, 8>>,
       ack: false, stream_id: 0}
+      iex> frame = %Kadabra.Frame{payload: <<0, 0, 0, 0, 0, 0, 0, 0>>,
+      ...> flags: 0x1, type: 0x6, stream_id: 0}
+      iex> Kadabra.Frame.Ping.new(frame)
+      %Kadabra.Frame.Ping{data: <<0, 0, 0, 0, 0, 0, 0, 0>>, ack: true,
+      stream_id: 0}
   """
-  @spec new(<<_::64>> | none()) :: t
+  @spec new(<<_::64>> | none() | Frame.t()) :: t
   def new(nil), do: new(@empty_payload)
 
   def new(<<data::64>>) do
@@ -39,18 +46,6 @@ defmodule Kadabra.Frame.Ping do
     }
   end
 
-  @doc ~S"""
-  Initializes a new `Frame.Ping` given a `Frame`.
-
-  ## Examples
-
-      iex> frame = %Kadabra.Frame{payload: <<0, 0, 0, 0, 0, 0, 0, 0>>,
-      ...> flags: 0x1, type: 0x6, stream_id: 0}
-      iex> Kadabra.Frame.Ping.new(frame)
-      %Kadabra.Frame.Ping{data: <<0, 0, 0, 0, 0, 0, 0, 0>>, ack: true,
-      stream_id: 0}
-  """
-  @spec new(Frame.t()) :: t
   def new(%Frame{type: 0x6, payload: <<data::64>>, flags: flags, stream_id: sid}) do
     %__MODULE__{
       ack: ack?(flags),

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -13,25 +13,24 @@ defmodule Kadabra.Frame.Ping do
           stream_id: integer
         }
 
+  @empty_payload <<0, 0, 0, 0, 0, 0, 0, 0>>
+
   @doc ~S"""
-  Returns new unacked ping frame.
+  Returns new unacked ping frame. Optionally takes a payload of 8 bytes, which
+  can be used to help calculate RTT times of pings that your application sends.
 
   ## Examples
 
       iex> Kadabra.Frame.Ping.new
       %Kadabra.Frame.Ping{data: <<0, 0, 0, 0, 0, 0, 0, 0>>,
       ack: false, stream_id: 0}
+      iex> Kadabra.Frame.Ping.new(payload: <<1, 2, 3, 4, 5, 6, 7, 8>>)
+      %Kadabra.Frame.Ping{data: <<1, 2, 3, 4, 5, 6, 7, 8>>,
+      ack: false, stream_id: 0}
   """
-  @spec new() :: t
-  def new do
-    %__MODULE__{
-      ack: false,
-      data: <<0, 0, 0, 0, 0, 0, 0, 0>>,
-      stream_id: 0
-    }
-  end
+  @spec new(<<_::64>> | none()) :: t
+  def new(nil), do: new(@empty_payload)
 
-  @spec new(<<_::64>>) :: t
   def new(<<data::64>>) do
     %__MODULE__{
       ack: false,

--- a/lib/frame/ping.ex
+++ b/lib/frame/ping.ex
@@ -31,6 +31,15 @@ defmodule Kadabra.Frame.Ping do
     }
   end
 
+  @spec new(<<_::64>>) :: t
+  def new(<<data::64>>) do
+    %__MODULE__{
+      ack: false,
+      data: <<data::64>>,
+      stream_id: 0
+    }
+  end
+
   @doc ~S"""
   Initializes a new `Frame.Ping` given a `Frame`.
 

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -147,17 +147,17 @@ defmodule Kadabra do
       iex> {:ok, pid} = Kadabra.open('https://http2.golang.org')
       iex> Kadabra.ping(pid)
       iex> receive do
-      ...>   {:pong, _pid} -> "got pong!"
+      ...>   {:pong, _pid, _resp} -> "got pong!"
       ...> end
       "got pong!"
+      iex> Kadabra.ping(pid, <<1::64>>) # Send 8-byte data
+      iex> receive do
+      ...>   {:pong, _pid, <<1::64>>} -> "got our data back!"
+      ...> end
+      "got our data back!"
   """
-  @spec ping(pid) :: no_return
-  def ping(pid) do
-    Kadabra.ConnectionPool.ping(pid)
-  end
-
-  @spec ping(pid, <<_::64>>) :: no_return
-  def ping(pid, data) when byte_size(data) == 8 do
+  @spec ping(pid, <<_::64>> | none) :: no_return
+  def ping(pid, data \\ nil) when is_nil(data) or byte_size(data) == 8 do
     Kadabra.ConnectionPool.ping(pid, data)
   end
 

--- a/lib/kadabra.ex
+++ b/lib/kadabra.ex
@@ -156,6 +156,11 @@ defmodule Kadabra do
     Kadabra.ConnectionPool.ping(pid)
   end
 
+  @spec ping(pid, <<_::64>>) :: no_return
+  def ping(pid, data) when byte_size(data) == 8 do
+    Kadabra.ConnectionPool.ping(pid, data)
+  end
+
   @doc ~S"""
   Makes a request with given headers and optional body.
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Kadabra.Mixfile do
   defp deps do
     [
       {:certifi, "~> 2.5"},
+      {:telemetry, "~> 1.2"},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -30,5 +30,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
   "scribe": {:hex, :scribe, "0.4.1", "4bf5395fb882995f705172b817b9a4ccae6ac83f9918fdedb6a2b9dafb57ec5f", [:mix], [{:pane, "~> 0.1", [hex: :pane, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
Hi! We've been troubleshooting some latency issues around our push notifications, and that led to adding some additional telemetry to this library so we could turn on some detailed logging and generate some good data to help us track down these problems. I'm happy to update more docs as well to document the usage of these events if desired. Also, I'm happy to update this to make `:telemetry` an optional dependency and update how we emit these so that it is only done if the `:telemetry` module is loaded, but I wasn't sure of the value of that.

I added telemetry events & metrics to the following modules:

* `lib/connection.ex` - telemetry event `[:kadabra, :connection, :stop]` added, with the duration of the connection logged. This has been helpful for understanding the lifecycle of both our FCM and APNS connections.
* `lib/socket.ex` - telemetry events `[:kadabra, :socket, :recv_frame], [:kadabra, :socket, :send], [:kadabra, :socket, :closed]`. I just went ahead and included the frame received and data being sent. I found these useful when trying to understand why our connections were being closed, like seeing the `GOAWAY` frames or the messages we sent leading up to that.
* `lib/stream.ex` - telemetry events `[:kadabra, :stream, :start], [:kadabra, :stream, :stop]`, with the duration of the lifetime of the stream included. This was useful for us to gather metrics on the lifetime of requests as well as to see how many streams were being created.


In this change is also an API breaking change -- updates to `ping`. Another thing we attempted to gather metrics on was the RTT of pings over these connections, and by allowing for us to specify an optional payload in the ping, we could calculate the RTT time from the pong response received without having to worry about out-of-order ping responses when sent around the same time. You can still just call `Kadabra.ping(pid)`, but I couldn't think of a way to return the payload when we get the response from the server without making it so that the data in the ping frame was always included in the message sent to the calling process.