### PR TITLE
Fix Socket usage in OTP28

### DIFF
--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -2,6 +2,7 @@ defmodule Kadabra.Socket do
   @moduledoc false
 
   defstruct socket: nil, buffer: "", active_user: nil
+  defguardp is_ssl_socket(s) when is_tuple(s) and elem(s, 0) == :sslsocket
 
   alias Kadabra.FrameParser
 
@@ -130,7 +131,7 @@ defmodule Kadabra.Socket do
 
   # Internal socket helpers
 
-  defp socket_send({:sslsocket, _, _} = pid, bin) do
+  defp socket_send(pid, bin) when is_ssl_socket(pid) do
     # IO.puts("Sending #{byte_size(bin)} bytes")
     :ssl.send(pid, bin)
   end
@@ -139,7 +140,7 @@ defmodule Kadabra.Socket do
     :gen_tcp.send(pid, bin)
   end
 
-  defp setopts({:sslsocket, _, _} = pid, opts) do
+  defp setopts(pid, opts) when is_ssl_socket(pid) do
     :ssl.setopts(pid, opts)
   end
 


### PR DESCRIPTION
I ran into problems (using pigeon with FCM) with elixir 1.18.4-otp-28 

Calling `:ssl.connect/3` result seems not to match `{:sslsocket, _, _}`, which leads to `Socket.socket_send/2` calling `:gen_tcp` instead of `:ssl`.

In my tests calling :ssl.connect did return:
- OTP27: `{:sslsocket, {:gen_tcp, #Port<0.832>, :tls_connection, :undefined},
  [#PID<0.21374.0>, #PID<0.21372.0>]}}`.
- OTP28:  `{:sslsocket, #Port<0.831>, #PID<0.21216.0>, #PID<0.21215.0>, :gen_tcp,
  :tls_gen_connection, #Reference<0.4258650642.1733689345.84442>, :undefined}}`.
  
I did add a guard that just checks for the first tuple element, this does solve the error I had using Pigeon to connect to fcm.googleapis.com