### PR TITLE
fix(socket): set customize_hostname_check for TLS wildcard matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Hostname verification now accepts wildcard certificates (e.g. `*.googleapis.com`)
+  by setting `customize_hostname_check` for RFC 6125 wildcard matching. ([#60](https://github.com/codedge-llc/kadabra/pull/60))
+
 ## [0.6.2] - 2026-02-22
 
 ### Fixed

--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -87,6 +87,8 @@ defmodule Kadabra.Socket do
         {:verify, :verify_peer},
         {:depth, 99},
         {:cacerts, :certifi.cacerts()},
+        {:customize_hostname_check,
+         [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]},
         {:alpn_advertised_protocols, [<<"h2">>]},
         :binary
       ]


### PR DESCRIPTION
## Summary

`Kadabra.Socket` opens `:https` connections with `verify: :verify_peer` but never sets [`customize_hostname_check`](https://www.erlang.org/doc/apps/ssl/ssl.html#customize_hostname_check-hostnamecheckopts). Without it, OTP's default hostname matcher compares DNS names by literal equality and skips [RFC 6125](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.3) wildcard matching, so a server presenting only a wildcard SAN (e.g. `*.googleapis.com`) for a concrete host (`fcm.googleapis.com`) is rejected and the TLS handshake fails — fatal at boot for anything opening a Kadabra connection in its supervision tree (e.g. Pigeon's FCM dispatcher).

## Impact

We use Kadabra via [Pigeon](https://github.com/codedge-llc/pigeon) for FCM push notifications. Around **05:45 CEST** Google began serving an `fcm.googleapis.com` edge cert whose only matching SAN is the wildcard `*.googleapis.com` (no exact entry). Every connection then crashed at startup:

```
TLS :client: In state :wait_cert_cr at ssl_handshake.erl:2221 generated CLIENT ALERT: Fatal - Bad Certificate
 - {:bad_cert,
 {:hostname_check_failed, {:requested, ~c"fcm.googleapis.com"},
  {:received,
   [
     dNSName: ~c"upload.video.google.com",
     dNSName: ~c"*.clients.google.com",
     dNSName: ~c"*.docs.google.com",
     dNSName: ~c"*.drive.google.com",
     dNSName: ~c"*.gdata.youtube.com",
     dNSName: ~c"*.googleapis.com",
     dNSName: ~c"*.photos.google.com",
     dNSName: ~c"*.youtube-3rd-party.com",
     dNSName: ~c"upload.google.com",
     dNSName: ~c"*.upload.google.com",
     dNSName: ~c"upload.youtube.com",
     dNSName: ~c"*.upload.youtube.com",
     dNSName: ~c"uploads.stage.gdata.youtube.com",
     dNSName: ~c"bg-call-donation.goog",
     dNSName: ~c"bg-call-donation-alpha.goog",
     dNSName: ~c"bg-call-donation-canary.goog",
     dNSName: ~c"bg-call-donation-dev.goog"
   ]}}}
```

`*.googleapis.com` covers the requested host, but the default matcher refuses the wildcard.

## Fix

Add the HTTPS match_fun to the default `:https` options:

```elixir
{:customize_hostname_check,
 [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]},
```

[`pkix_verify_hostname_match_fun(:https)`](https://www.erlang.org/doc/apps/public_key/public_key.html#pkix_verify_hostname_match_fun/1) is the only thing that routes DNS pairs into wildcard matching; ssl uses it solely via [`customize_hostname_check`](https://www.erlang.org/doc/apps/ssl/ssl.html#customize_hostname_check-hostnamecheckopts). Caller `:ssl` opts still win — they're prepended and `:ssl` honors the first occurrence.

## Verification

- OTP 28, wildcard-only `*.googleapis.com` cert: [`pkix_verify_hostname/2`](https://www.erlang.org/doc/apps/public_key/public_key.html#pkix_verify_hostname/2) returns `false` with the default matcher, `true` with `pkix_verify_hostname_match_fun(:https)`.
- `mix test` green on pinned toolchain (Elixir 1.19 / OTP 28): 47 doctests, 24 tests, 0 failures.
